### PR TITLE
Fix comment typo in corne.conf

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -15,7 +15,7 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=3
 CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
 CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=5
 
-# Bluetoothe experimental features
+# Bluetooth experimental features
 CONFIG_ZMK_BLE_EXPERIMENTAL_FEATURES=y
 
 # Enable mouse emulation


### PR DESCRIPTION
## Summary
- correct typo in comment referencing Bluetooth features

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840edafc5f0832fb8443081bd26a1c6